### PR TITLE
Adding support for Split - multi-value separator

### DIFF
--- a/README
+++ b/README
@@ -96,6 +96,16 @@ USAGE
     Changing the separator may be necessary, if you want to use a "|" in one
     of the patterns in the controlling lines.
 
+Split
+
+    You can change the separator string for multi-value customfields (initially
+    ",") in the template with:
+
+        Split=<anyregexp>
+
+    Changing the mult-value separator may be necessary since your source may
+    use a list of values separated by spaces or ', ' or ';' etc.
+
   Examples
     For reference, a template with these examples is also installed during
     make initdb. See the CustomFieldScannerExample template for examples and

--- a/lib/RT/Action/ExtractCustomFieldValues.pm
+++ b/lib/RT/Action/ExtractCustomFieldValues.pm
@@ -41,6 +41,7 @@ sub TemplateConfig {
     }
 
     my $Separator = '\|';
+    my $Split = ',';
     my @lines = split( /[\n\r]+/, $content);
     my @results;
     for (@lines) {
@@ -53,10 +54,15 @@ sub TemplateConfig {
             $Separator = $1;
             next;
         }
+        if (/^Split=(.+)$/) {
+            $Split = $1;
+            next;
+        }
         my %line;
         @line{qw/CFName Field Match PostEdit Options/}
             = split(/$Separator/);
         $_ = '' for grep !defined, values %line;
+        %line{Split} = $Split;
         push @results, \%line;
     }
     return \@results;
@@ -220,7 +226,7 @@ sub ProcessCF {
     if ( $args{CustomField}->SingleValue() ) {
         push @values, $args{Value};
     } else {
-        @values = split( ',', $args{Value} );
+        @values = split( $args{Split}, $args{Value} );
     }
 
     foreach my $value ( grep defined && length, @values ) {

--- a/lib/RT/Extension/ExtractCustomFieldValues.pm
+++ b/lib/RT/Extension/ExtractCustomFieldValues.pm
@@ -134,6 +134,16 @@ template with:
 Changing the separator may be necessary, if you want to use a "|" in
 one of the patterns in the controlling lines.
 
+=head2 Split
+
+You can change the separator string for multi-value customfields (initially
+",") in the template with:
+
+        Split=<anyregexp>
+
+Changing the mult-value separator may be necessary since your source may
+use a list of values separated by spaces or ', ' or ';' etc.
+
 =head2 Examples
 
 For reference, a template with these examples is also installed during


### PR DESCRIPTION
We only handle multi-valued CustomFields separated by ','s. This adds support for arbitrary reg-exps for the incoming data on a line by line basis (like Separator).
Once Split is set it remains in effect until reset to another value.
Split defaults to ',' for backwards compatibility.