### PR TITLE
If we are stuck with html, optionally convert it to plain text

### DIFF
--- a/README
+++ b/README
@@ -87,6 +87,10 @@ USAGE
             matching values will be added to the CF, which should probably
             be a multi-value CF for best results. (Superceded by '*'.)
 
+        *s* - (scrub)
+            If our only message body is text/html, use this option to
+            convert it to plain text before trying to extract values.
+
   Separator
     You can change the separator string (initially "\|") during the template
     with:

--- a/lib/RT/Action/ExtractCustomFieldValues.pm
+++ b/lib/RT/Action/ExtractCustomFieldValues.pm
@@ -196,6 +196,10 @@ sub FindContent {
             next if $LastContent eq $content;
             $RT::Logger->debug( "Examining content of body" );
             $LastContent = $content;
+            # If we ended up with just html, maybe convert it to text
+            if ( $args{Options} =~ /s/ && lc $ct eq 'text/html' ) {
+                $content = RT::Interface::Email::ConvertHTMLToText( $content );
+            }
             $args{Callback}->( $content );
         }
     } elsif ( lc $args{Field} eq 'headers' ) {

--- a/lib/RT/Extension/ExtractCustomFieldValues.pm
+++ b/lib/RT/Extension/ExtractCustomFieldValues.pm
@@ -120,6 +120,11 @@ The MatchString regex will be applied with the /g option and all
 matching values will be added to the CF, which should probably be a
 multi-value CF for best results.  (Superceded by '*'.)
 
+=item I<s> - (scrub)
+
+If our only message body is text/html, use this option to convert it
+to plain text before trying to extract values.
+
 =back
 
 =back


### PR DESCRIPTION
External ticket sources such as intake forms often supply only html messages. This is a simple way to make extracting data from those messages much easier.